### PR TITLE
Added default values for closed and label args of resample function i…

### DIFF
--- a/xarray/core/common.py
+++ b/xarray/core/common.py
@@ -749,7 +749,21 @@ class DataWithCoords(SupportsArithmetic, AttrAccessMixin):
         dim_coord = self[dim]
 
         if isinstance(self.indexes[dim_name], CFTimeIndex):
+            from ..coding.cftime_offsets import to_offset
             from .resample_cftime import CFTimeGrouper
+            end_types = {'M', 'A'}
+            rule = to_offset(freq).rule_code()
+            if (rule in end_types or
+                    ('-' in rule and rule[:rule.find('-')] in end_types)):
+                if closed is None:
+                    closed = 'right'
+                if label is None:
+                    label = 'right'
+            else:
+                if closed is None:
+                    closed = 'left'
+                if label is None:
+                    label = 'left'
             grouper = CFTimeGrouper(freq, closed, label, base)
         else:
             # TODO: to_offset() call required for pandas==0.19.2

--- a/xarray/core/resample_cftime.py
+++ b/xarray/core/resample_cftime.py
@@ -78,18 +78,8 @@ def _get_time_bins(index, freq, closed, label, base):
                                           start=first,
                                           end=last,
                                           name=index.name)
-    print('XARRAY-START')
-    print(index.min(), index.max())
-    print(first, last)
-    print('initial range\n', datetime_bins)
-    print('len binner: ', len(datetime_bins),
-          'len labels: ', len(labels))
 
     datetime_bins = _adjust_bin_edges(datetime_bins, freq, closed, index)
-
-    print('len datetime_bins: ', len(datetime_bins),
-          'len labels: ', len(labels))
-    print('_adjust_bin_edges\n', datetime_bins)
 
     if closed == 'right':
         if label == 'right':
@@ -97,16 +87,9 @@ def _get_time_bins(index, freq, closed, label, base):
     elif label == 'right':
         labels = labels[1:]
 
-        print('len datetime_bins: ', len(datetime_bins),
-              'len labels: ', len(labels))
-
     if index.hasnans:  # cannot be true since CFTimeIndex does not allow NaNs
         datetime_bins = datetime_bins.insert(0, pd.NaT)
         labels = labels.insert(0, pd.NaT)
-
-        print('len binner: ', len(datetime_bins),
-              'len labels: ', len(labels))
-    print('XARRAY-END')
 
     return datetime_bins, labels
 

--- a/xarray/tests/test_cftimeindex.py
+++ b/xarray/tests/test_cftimeindex.py
@@ -377,9 +377,10 @@ def test_groupby(da):
 
 
 @pytest.mark.skipif(not has_cftime, reason='cftime not installed')
+@pytest.mark.xfail(raises=ValueError)
 def test_resample_error(da):
-    with pytest.raises(NotImplementedError, match='to_datetimeindex'):
-        da.resample(time='Y')
+    # with pytest.raises(NotImplementedError, match='to_datetimeindex'):
+    da.resample(time='Y')
 
 
 SEL_STRING_OR_LIST_TESTS = {

--- a/xarray/tests/test_dataarray.py
+++ b/xarray/tests/test_dataarray.py
@@ -2314,8 +2314,8 @@ class TestDataArray(object):
                                 calendar='noleap')
         array = DataArray(np.arange(12), [('time', times)])
 
-        with raises_regex(NotImplementedError, 'to_datetimeindex'):
-            array.resample(time='6H').mean()
+        # with raises_regex(NotImplementedError, 'to_datetimeindex'):
+        array.resample(time='6H').mean()
 
     def test_resample_first(self):
         times = pd.date_range('2000-01-01', freq='6H', periods=10)


### PR DESCRIPTION
Added default values for closed and label args of resample function in common.py. Cleaned up print statements. Modified tests that were written under the assumption that CFTimeIndex cannot be resampled so that the tests now pass.