### PR TITLE
Fix dask compatibility issues in `_decimal_year`

### DIFF
--- a/xarray/coding/calendar_ops.py
+++ b/xarray/coding/calendar_ops.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import warnings
-
 import numpy as np
 import pandas as pd
 
-from xarray.coding.cftime_offsets import date_range_like, get_date_type, to_offset
+from xarray.coding.cftime_offsets import date_range_like, get_date_type
 from xarray.coding.cftimeindex import CFTimeIndex
 from xarray.coding.times import (
     _should_cftime_be_used,
@@ -306,18 +304,19 @@ def _convert_to_new_calendar_with_new_day_of_year(
         return np.nan
 
 
-def _rollback(times, freq):
-    if times.dtype.kind == "M":
-        offset = pd.tseries.frequencies.to_offset(freq)
-    else:
-        offset = to_offset(freq)
-    return apply_ufunc(
-        offset.rollback,
-        times,
-        vectorize=True,
-        dask="parallelized",
-        output_dtypes=[times.dtype],
-    )
+def _decimal_year_cftime(time, year, days_in_year, *, date_class):
+    year_start = date_class(year, 1, 1)
+    delta = np.timedelta64(time - year_start, "ns")
+    days_in_year = np.timedelta64(days_in_year, "D")
+    return year + delta / days_in_year
+
+
+def _decimal_year_numpy(time, year, days_in_year, *, dtype):
+    time = np.asarray(time).astype(dtype)
+    year_start = np.datetime64(int(year) - 1970, "Y").astype(dtype)
+    delta = time - year_start
+    days_in_year = np.timedelta64(days_in_year, "D")
+    return year + delta / days_in_year
 
 
 def _decimal_year(times):
@@ -328,18 +327,22 @@ def _decimal_year(times):
     Ex: '2000-03-01 12:00' is 2000.1653 in a standard calendar,
       2000.16301 in a "noleap" or 2000.16806 in a "360_day".
     """
-    years = times.dt.year
-    floored_times = times.dt.floor("D")
-
-    # Explicitly cast to timedelta64[ns], since xarray's automatic conversion
-    # from datetime.timedelta to timedelta64[ns] does not occur for dask
-    # arrays of datetime.timedelta objects.
-    deltas = (times - _rollback(floored_times, "YS")).astype("timedelta64[ns]")
-
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="Converting non-nanosecond")
-        days_in_years = times.dt.days_in_year.astype("timedelta64[D]")
-    return years + deltas / days_in_years
+    if times.dtype == "O":
+        function = _decimal_year_cftime
+        kwargs = {"date_class": get_date_type(times.dt.calendar, True)}
+    else:
+        function = _decimal_year_numpy
+        kwargs = {"dtype": times.dtype}
+    return apply_ufunc(
+        function,
+        times,
+        times.dt.year,
+        times.dt.days_in_year,
+        kwargs=kwargs,
+        vectorize=True,
+        dask="parallelized",
+        output_dtypes=[np.float64],
+    )
 
 
 def interp_calendar(source, target, dim="time"):

--- a/xarray/core/accessor_dt.py
+++ b/xarray/core/accessor_dt.py
@@ -563,7 +563,7 @@ class DatetimeAccessor(TimeAccessor[T_DataArray]):
     @property
     def decimal_year(self) -> T_DataArray:
         """Convert the dates as a fractional year."""
-        result = _decimal_year(self._obj).astype(float)
+        result = _decimal_year(self._obj)
         newvar = Variable(
             dims=self._obj.dims,
             attrs=self._obj.attrs,


### PR DESCRIPTION
@aulemahal I think this should resolve the dask compatibility issues in `_decimal_year`.  I'm not sure how to make your original approach work for versions of NumPy < 2—it seems like it should if it weren't for [what looks like an old upstream issue](https://github.com/pydata/xarray/issues/9387#issuecomment-2306007750)—but this at least gets the rollback approach working.